### PR TITLE
setHookにundefinedを渡すとフック関数の登録を解除できるように

### DIFF
--- a/lib/sqlite3-webapi-kit.coffee
+++ b/lib/sqlite3-webapi-kit.coffee
@@ -384,9 +384,13 @@ Sqlite3WebApiKit = (->
   * @return {Boolean} 成功/失敗
   ###
   _setHook = (func) ->
-    return false if func not instanceof Function
-    _requestHook = func
-    true
+    if func instanceof Function
+      _requestHook = func
+      return true
+    else if func is undefined
+      _requestHook = -> true
+      return true
+    false
 
   ###*
   * httpインターフェースを公開

--- a/lib/sqlite3-webapi-kit.js
+++ b/lib/sqlite3-webapi-kit.js
@@ -483,11 +483,16 @@ Sqlite3WebApiKit = (function() {
   * @return {Boolean} 成功/失敗
    */
   _setHook = function(func) {
-    if (!(func instanceof Function)) {
-      return false;
+    if (func instanceof Function) {
+      _requestHook = func;
+      return true;
+    } else if (func === void 0) {
+      _requestHook = function() {
+        return true;
+      };
+      return true;
     }
-    _requestHook = func;
-    return true;
+    return false;
   };
 
   /**

--- a/test/test-http.coffee
+++ b/test/test-http.coffee
@@ -98,6 +98,12 @@ vows.describe('http server test')
       assert.isTrue topic
 
 .addBatch
+  'httpリクエスト時のフック関数の登録を解除':
+    topic: -> sqlited.setHook undefined
+    '登録解除に成功': (topic) =>
+      assert.isTrue topic
+
+.addBatch
   '存在しないhttpメソッドにアクセス':
     topic: -> GET '/', @callback
     'httpレスポンスステータスコード: 404': (topic) =>

--- a/test/test-http.coffee
+++ b/test/test-http.coffee
@@ -98,18 +98,18 @@ vows.describe('http server test')
       assert.isTrue topic
 
 .addBatch
-  'httpリクエスト時のフック関数の登録を解除':
-    topic: -> sqlited.setHook undefined
-    '登録解除に成功': (topic) =>
-      assert.isTrue topic
-
-.addBatch
   '存在しないhttpメソッドにアクセス':
     topic: -> GET '/', @callback
     'httpレスポンスステータスコード: 404': (topic) =>
       assert.equal topic.statusCode, 404
     '1001エラーが発生する': (topic) =>
       assert.equal topic.error.errno, 1001
+
+.addBatch
+  'httpリクエスト時のフック関数の登録を解除':
+    topic: -> sqlited.setHook undefined
+    '登録解除に成功': (topic) =>
+      assert.isTrue topic
 
 .addBatch
   'デフォルトhttpメソッド: /query':

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -193,6 +193,17 @@ vows.describe('http server test').addBatch({
     })(this)
   }
 }).addBatch({
+  'httpリクエスト時のフック関数の登録を解除': {
+    topic: function() {
+      return sqlited.setHook(void 0);
+    },
+    '登録解除に成功': (function(_this) {
+      return function(topic) {
+        return assert.isTrue(topic);
+      };
+    })(this)
+  }
+}).addBatch({
   '存在しないhttpメソッドにアクセス': {
     topic: function() {
       return GET('/', this.callback);

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -193,17 +193,6 @@ vows.describe('http server test').addBatch({
     })(this)
   }
 }).addBatch({
-  'httpリクエスト時のフック関数の登録を解除': {
-    topic: function() {
-      return sqlited.setHook(void 0);
-    },
-    '登録解除に成功': (function(_this) {
-      return function(topic) {
-        return assert.isTrue(topic);
-      };
-    })(this)
-  }
-}).addBatch({
   '存在しないhttpメソッドにアクセス': {
     topic: function() {
       return GET('/', this.callback);
@@ -216,6 +205,17 @@ vows.describe('http server test').addBatch({
     '1001エラーが発生する': (function(_this) {
       return function(topic) {
         return assert.equal(topic.error.errno, 1001);
+      };
+    })(this)
+  }
+}).addBatch({
+  'httpリクエスト時のフック関数の登録を解除': {
+    topic: function() {
+      return sqlited.setHook(void 0);
+    },
+    '登録解除に成功': (function(_this) {
+      return function(topic) {
+        return assert.isTrue(topic);
       };
     })(this)
   }


### PR DESCRIPTION
_setHookのコメントにはすでに書かれていましたが、undefinedでフック関数の登録を解除できるようにしました。